### PR TITLE
Optimize RmaDataGrid.php query

### DIFF
--- a/src/DataGrids/Admin/RmaDataGrid.php
+++ b/src/DataGrids/Admin/RmaDataGrid.php
@@ -57,7 +57,7 @@ class RmaDataGrid extends DataGrid
         $table_prefix = DB::getTablePrefix();
 
         $queryBuilder = DB::table('rma')
-            ->leftJoin('orders', 'orders.id', '=', 'rma.order_id')
+            ->join('orders', 'orders.id', '=', 'rma.order_id')
             ->addSelect(
                 'rma.id',
                 'rma.order_id',
@@ -68,8 +68,7 @@ class RmaDataGrid extends DataGrid
                 'rma.order_status as rma_order_status',
                 'rma.created_at',
                 'orders.status as order_status'
-            )
-            ->whereIn('order_id', DB::table('orders')->pluck('id')?->toArray());
+            );
                 
         $this->addFilter('id', 'rma.id');
         $this->addFilter('order_id', 'rma.order_id');


### PR DESCRIPTION
Why use a left join and then check if the order exists? We can just use an inner join. Also, if I have a couple of thousand orders and the old code, it might break due to SQL query limits.