### PR TITLE
Bug Fix: resolution reason field in rma create is one step behind resolution type change

### DIFF
--- a/src/Resources/views/admin/sales/rma/create/rma-create.blade.php
+++ b/src/Resources/views/admin/sales/rma/create/rma-create.blade.php
@@ -411,7 +411,7 @@ $customAttributes = app('Webkul\RMA\Repositories\RmaCustomFieldRepository')->wit
                                             ::name="'resolution_type[' + getProductId(product) + ']'" 
                                             rules="required"
                                             v-model="resolutionType[getProductId(product)]"
-                                            @change="getResolutionReason(getProductId(product))"
+                                            @change="$nextTick(() => getResolutionReason(getProductId(product)))"
                                             :label="trans('rma::app.admin.configuration.index.sales.rma.resolution-type')"
                                         >
                                             <option value="">
@@ -458,7 +458,7 @@ $customAttributes = app('Webkul\RMA\Repositories\RmaCustomFieldRepository')->wit
                                             ::name="'resolution_type[' + getProductId(product) + ']'" 
                                             rules="required"
                                             v-model="resolutionType[getProductId(product)]"
-                                            @change="getResolutionReason(getProductId(product))"
+                                            @change="$nextTick(() => getResolutionReason(getProductId(product)))"
                                             :label="trans('rma::app.admin.configuration.index.sales.rma.resolution-type')"
                                         >
                                             <option value="">

--- a/src/Resources/views/shop/customer/rma/create.blade.php
+++ b/src/Resources/views/shop/customer/rma/create.blade.php
@@ -534,7 +534,7 @@ $customAttributes = app('Webkul\RMA\Repositories\RmaCustomFieldRepository')->wit
                                             ::name="'resolution_type[' + getProductId(product) + ']'" 
                                             rules="required"
                                             v-model="resolutionType[getProductId(product)]"
-                                            @change="getResolutionReason(getProductId(product))"
+                                            @change="$nextTick(() => getResolutionReason(getProductId(product)))"
                                             :label="trans('rma::app.admin.configuration.index.sales.rma.resolution-type')"
                                         >
                                             <option value="">
@@ -581,7 +581,7 @@ $customAttributes = app('Webkul\RMA\Repositories\RmaCustomFieldRepository')->wit
                                             ::name="'resolution_type[' + getProductId(product) + ']'" 
                                             rules="required"
                                             v-model="resolutionType[getProductId(product)]"
-                                            @change="getResolutionReason(getProductId(product))"
+                                            @change="$nextTick(() => getResolutionReason(getProductId(product)))"
                                             :label="trans('rma::app.admin.configuration.index.sales.rma.resolution-type')"
                                         >
                                             <option value="">

--- a/src/Resources/views/shop/guest/create.blade.php
+++ b/src/Resources/views/shop/guest/create.blade.php
@@ -572,7 +572,7 @@ $customAttributes = app('Webkul\RMA\Repositories\RmaCustomFieldRepository')->wit
                                             ::name="'resolution_type[' + getProductId(product) + ']'" 
                                             rules="required"
                                             v-model="resolutionType[getProductId(product)]"
-                                            @change="getResolutionReason(getProductId(product))"
+                                            @change="$nextTick(() => getResolutionReason(getProductId(product)))"
                                             :label="trans('rma::app.admin.configuration.index.sales.rma.resolution-type')"
                                         >
                                             <option value="">

--- a/src/Resources/views/shop/guest/create.blade.php
+++ b/src/Resources/views/shop/guest/create.blade.php
@@ -525,7 +525,7 @@ $customAttributes = app('Webkul\RMA\Repositories\RmaCustomFieldRepository')->wit
                                             ::name="'resolution_type[' + getProductId(product) + ']'" 
                                             rules="required"
                                             v-model="resolutionType[getProductId(product)]"
-                                            @change="getResolutionReason(getProductId(product))"
+                                            @change="$nextTick(() => getResolutionReason(getProductId(product)))"
                                             :label="trans('rma::app.admin.configuration.index.sales.rma.resolution-type')"
                                         >
                                             <option value="">


### PR DESCRIPTION
@ change is called before v-model is filled with the selected value - after my change it is called after, so it works.