### PR TITLE
Remove style loading in bagisto.shop.layout.rma.guest.login.before

### DIFF
--- a/src/Providers/EventServiceProvider.php
+++ b/src/Providers/EventServiceProvider.php
@@ -39,9 +39,5 @@ class EventServiceProvider extends ServiceProvider
         Event::listen('bagisto.admin.layout.head.before', function ($viewRenderEventManager) {
             $viewRenderEventManager->addTemplate('rma::style.index');
         });
-
-        Event::listen('bagisto.shop.layout.rma.guest.login.before', function ($viewRenderEventManager) {
-            $viewRenderEventManager->addTemplate('rma::style.index');
-        });
     }
 }


### PR DESCRIPTION
It was duplicated, because guest login uses layout, so the style file was already there.